### PR TITLE
Changed used NwPluginAPI assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Project now uses NwPluginAPI assembly directly from game files to use more up to date API.
+
 ## [3.1.0] - 2024-06-10
 
 ### Changed

--- a/PluginCommands.UnitTests/Commands/PluginCommandsTests.cs
+++ b/PluginCommands.UnitTests/Commands/PluginCommandsTests.cs
@@ -73,7 +73,7 @@ public class PluginCommandsTests
         senderMock.VerifyNoOtherCalls();
     }
 
-    //[TestCaseSource(nameof(ValidPluginTestCases))]
+    [TestCaseSource(nameof(ValidPluginTestCases))]
     public void Execute_ShouldSucceed_WhenGoldFlow(ICommand command, string pluginName)
     {
         // Arrange

--- a/PluginCommands.UnitTests/PluginCommands.UnitTests.csproj
+++ b/PluginCommands.UnitTests/PluginCommands.UnitTests.csproj
@@ -14,7 +14,6 @@
 		<PackageReference Include="FluentAssertions" Version="8.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Northwood.PluginAPI" Version="13.1.2" />
 		<PackageReference Include="NUnit" Version="4.3.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
 	</ItemGroup>
@@ -27,6 +26,7 @@
 		<Reference Include="Mirror" HintPath="$(SL_REFERENCES)/Mirror.dll" />
 		<Reference Include="netstandard" HintPath="$(SL_REFERENCES)/netstandard.dll" />
 		<Reference Include="NorthwoodLib" HintPath="$(SL_REFERENCES)/NorthwoodLib.dll" />
+		<Reference Include="PluginAPI" HintPath="$(SL_REFERENCES)/PluginAPI.dll" />
 		<Reference Include="UnityEngine.CoreModule" HintPath="$(SL_REFERENCES)/UnityEngine.CoreModule.dll" />
 	</ItemGroup>
 </Project>

--- a/PluginCommands.UnitTests/PluginCommands.UnitTests.csproj
+++ b/PluginCommands.UnitTests/PluginCommands.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 		<PlatformTarget>x64</PlatformTarget>
 		<OutputType>Library</OutputType>
 		<AssemblyName>PluginCommands.UnitTests</AssemblyName>

--- a/PluginCommands/PluginCommands.csproj
+++ b/PluginCommands/PluginCommands.csproj
@@ -12,11 +12,9 @@
 		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Northwood.PluginAPI" Version="13.1.2" />
-	</ItemGroup>
-	<ItemGroup>
 		<Reference Include="Assembly-CSharp" HintPath="$(SL_REFERENCES)/Assembly-CSharp.dll" />
 		<Reference Include="CommandSystem.Core" HintPath="$(SL_REFERENCES)/CommandSystem.Core.dll" />
 		<Reference Include="NorthwoodLib" HintPath="$(SL_REFERENCES)/NorthwoodLib.dll" />
+		<Reference Include="PluginAPI" HintPath="$(SL_REFERENCES)/PluginAPI.dll" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
The aim is to prevent compatibility issues with newer game versions due to Northwood's NuGet package not getting updated.

## Resolution
Project now uses PluginAPI assembly directly from game files.

## Testing Evidence
Tested on local server instance.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
