### PR TITLE
Made plugin transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2025-09-05
+
 ### Changed
 
-- Upgraded project to [LabAPI v1.1.0](https://github.com/northwood-studios/LabAPI/releases/tag/1.1.0).
+- Upgraded project to [LabAPI v1.1.1](https://github.com/northwood-studios/LabAPI/releases/tag/1.1.1).
 
 ## [4.0.0] - 2025-05-20
 

--- a/PluginCommands/Commands/PluginCommandBase.cs
+++ b/PluginCommands/Commands/PluginCommandBase.cs
@@ -12,11 +12,6 @@ namespace PluginCommands.Commands;
 public abstract class PluginCommandBase : IUsageProvider
 {
     /// <summary>
-    /// Tells whether or not command response should be sanitized.
-    /// </summary>
-    public bool SanitizeResponse => true;
-
-    /// <summary>
     /// Defines command usage prompts.
     /// </summary>
     public string[] Usage { get; } = ["Plugin Name"];

--- a/PluginCommands/PluginCommands.csproj
+++ b/PluginCommands/PluginCommands.csproj
@@ -13,7 +13,7 @@
 		<Platforms>AnyCPU</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Northwood.LabAPI" Version="1.1.0" />
+		<PackageReference Include="Northwood.LabAPI" Version="1.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="Assembly-CSharp" HintPath="$(SL_REFERENCES)/Assembly-CSharp.dll" />

--- a/PluginCommands/PluginCommandsPlugin.cs
+++ b/PluginCommands/PluginCommandsPlugin.cs
@@ -20,7 +20,7 @@ public class PluginCommandsPlugin : Plugin
     /// <summary>
     /// Contains current plugin version.
     /// </summary>
-    public const string PluginVersion = "4.0.0";
+    public const string PluginVersion = "4.1.0";
 
     /// <summary>
     /// Contains plugin description.
@@ -46,6 +46,9 @@ public class PluginCommandsPlugin : Plugin
 
     /// <inheritdoc />
     public override Version RequiredApiVersion { get; } = new(LabApiProperties.CompiledVersion);
+
+    /// <inheritdoc />
+    public override bool IsTransparent => true;
 
     /// <summary>
     /// Parent command reference for manual commands registration.


### PR DESCRIPTION
## Description
New LabAPI version added a new `IsTransparent` property which is disabled by default.

## Resolution
Updated the project to the newset LabAPI version and removed old unused code.

## Testing Evidence
Tested on local server instance.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
